### PR TITLE
perf: vite-plugin-image-optimizer통한 이미지 에셋 최적화 총 용량 90% 감소

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "msw": "^2.10.3",
         "prettier": "^3.5.3",
         "vite": "^6.0.1",
+        "vite-plugin-image-optimizer": "^2.0.2",
         "vite-plugin-pwa": "^0.21.1",
         "vitest": "^3.2.4",
         "workbox-core": "^7.3.0",
@@ -4285,6 +4286,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ansi-escapes": {
@@ -10773,6 +10784,33 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-plugin-image-optimizer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-image-optimizer/-/vite-plugin-image-optimizer-2.0.2.tgz",
+      "integrity": "sha512-BYK27SpSScRIaveJVjbP7EjSrawuCc+ffESGvKVRhByAu6RGvwE3EyGg9ZeqQiLUE8e1hKSCr8v5ZfvQNiqvJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "pathe": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "sharp": ">=0.34.0",
+        "svgo": ">=4",
+        "vite": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "sharp": {
+          "optional": true
+        },
+        "svgo": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite-plugin-pwa": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "msw": "^2.10.3",
     "prettier": "^3.5.3",
     "vite": "^6.0.1",
+    "vite-plugin-image-optimizer": "^2.0.2",
     "vite-plugin-pwa": "^0.21.1",
     "vitest": "^3.2.4",
     "workbox-core": "^7.3.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,8 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { ViteImageOptimizer } from 'vite-plugin-image-optimizer'
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     react({
@@ -10,7 +10,26 @@ export default defineConfig({
       babel: {
         plugins: ['@emotion/babel-plugin'],
       },
-    })
+    }),
+    ViteImageOptimizer({
+      jpg: {
+        quality: 80,
+      },
+      jpeg: {
+        quality: 80,
+        progressive: true,
+        optimiseCoding: true
+      },
+      png: {
+        quality: 80,
+        strip: true,
+        palette: true,
+      },
+      webp: {
+        lossless: false,
+        quality: 75,
+      },
+    }),
   ],
   test: {
     globals: true,


### PR DESCRIPTION
### 문제점 (Problem)
프로덕션 빌드 시 `popular-*.jpg`와 같은 이미지 파일들의 원본 크기(개당 1.5MB ~ 2MB)가 그대로 유지되어, 웹사이트 초기 로딩 속도에 심각한 병목 현상을 유발

### 해결 방안 (Solution)
`vite-plugin-image-optimizer` 플러그인을 도입하고 세부 설정을 추가하여, 빌드 과정에서 이미지 에셋이 자동으로 압축 및 최적화되도록 구성

- **`vite.config.js` 설정 추가:**
  - `jpg`, `jpeg`: `quality`, `progressive` 옵션 등을 설정하여 압축률을 높였습니다.
  - `png`: `quality` 조정 및 메타데이터 제거(`strip`) 옵션으로 파일 크기를 최적화했습니다.

### 결과 (Result)
- 빌드 결과, 이미지 에셋의 총 용량이 **약 90% 감소**했습니다. 
-  total savings = 7524.27kB/8353.92kB ≈ 90%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an image optimization plugin to the development environment for improved build processing of images.

* **New Features**
  * Enhanced image optimization during the build process, resulting in better performance and reduced image sizes for JPEG, PNG, and WebP formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->