### PR TITLE
fix: HTTPS 트래픽의 캐시 설정 고려 nginx 파일 수정

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,20 @@
+# HTTP (port 80) 서버 블록: 모든 요청을 HTTPS로 리디렉션합니다.
 server {
     listen 80;
+    server_name haruhan.site; # 여기에 도메인 이름을 명시합니다.
+    return 301 https://$server_name$request_uri;
+}
+
+# HTTPS (port 443) 서버 블록: 실제 앱 로직을 처리합니다.
+server {
+    listen 443 ssl;
+    server_name haruhan.site; # 여기에 도메인 이름을 명시합니다.
+
+    # --- SSL 인증서 경로 (매우 중요) ---
+    # 아래 경로는 실제 서버의 인증서 위치에 맞게 수정해야 할 수 있습니다.
+    # 일반적으로 Let's Encrypt를 사용하면 아래와 비슷한 경로에 위치합니다.
+    ssl_certificate /etc/letsencrypt/live/haruhan.site/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/haruhan.site/privkey.pem;
 
     # 모든 요청에 대해 /usr/share/nginx/html 디렉토리에서 파일을 찾습니다.
     root /usr/share/nginx/html;
@@ -13,7 +28,6 @@ server {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss;
 
     # SPA(Single Page Application)를 위한 설정
-    # 요청된 URI가 파일이나 디렉토리로 존재하지 않으면 index.html을 반환합니다.
     location / {
         try_files $uri $uri/ /index.html;
         # index.html은 캐시하지 않도록 설정
@@ -21,7 +35,6 @@ server {
     }
 
     # 이름에 해시가 포함된 정적 파일들에 대한 캐시 정책
-    # js, css, 이미지 등은 내용이 바뀌면 파일 이름도 바뀌므로 길게 캐싱합니다.
     location ~* \.(?:css|js|jpg|jpeg|gif|png|ico|webp|svg)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";


### PR DESCRIPTION
HTTPS vs HTTP 설정 불일치
문제의 핵심:
우리가 만든 nginx.conf는 listen 80; (HTTP)만 처리하도록 설정되어 있음
하지만 실제 사이트는 https://haruhan.site (HTTPS, 443포트)로 접속하고 있음
결과적으로 HTTPS 트래픽은 우리의 캐시 설정을 전혀 사용하지 않고 있었음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * All HTTP requests are now automatically redirected to the secure HTTPS version of the site.
  * Improved security with SSL enabled for all traffic to haruhan.site.

* **Chores**
  * Updated server configuration to better separate HTTP and HTTPS handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->