### PR TITLE
hotfix: Jenkins 빌드 오류 긴급 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # package.json과 package-lock.json만 먼저 복사하여 의존성 설치
 COPY package.json package-lock.json ./
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 # 이후 소스 코드 복사 (이전에 package.json만 복사하는 이유: Docker 캐싱 최적화)
 COPY . . 


### PR DESCRIPTION
Dockerfile에서 npm install 실행 시 --legacy-peer-deps 옵션을 추가하여 CI 환경의 빌드 오류를 해결